### PR TITLE
Multi-bridge support, Homebridge v2 compatibility, lint clean-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Support for running multiple Tedee bridges as separate platform instances. Each instance must have a unique `name` and `webhookPort` in `config.json`.
+
+### Changed
+- Removed the `singular: true` flag from the config schema so the Homebridge UI allows more than one TedeeBridge platform entry.
+- `saveAddr()` now identifies its own platform block by `name` when more than one TedeeBridge entry is present, instead of always overwriting the first match.
+- The webhook server now logs a clear error if its port is already in use rather than crashing without context.
+- Widened `engines.node` to `^18.20.4 || ^20.15.1 || ^22 || ^24` and `engines.homebridge` to `^1.6.0 || ^2.0.0-beta.0` for Homebridge v2 compatibility. The plugin already uses the v2-compatible `Service.Battery` API; no code changes were needed for v2.
+- Cleared all pre-existing eslint errors and warnings under the existing `--max-warnings=0` config (`@ts-ignore` → `@ts-expect-error` or proper type assertions, `==`/`!=` → `===`/`!==`, long log strings wrapped, unused parameter dropped).
+
+### Fixed
+- `registerLocks()` no longer crashes on startup when the optional `devices` array is omitted from the config.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm install -g homebridge-tedee-bridge
   "platforms": [
     {
       "platform": "TedeeBridge",
+      "name": "TedeeBridge",
       "apiKey": "TEDEE-API-KEY",
       "devices": [
         {
@@ -43,15 +44,45 @@ npm install -g homebridge-tedee-bridge
 
 #### Platform
 
-| Parameter         | Required | Description                                                                                 |
-|-------------------|----------|---------------------------------------------------------------------------------------------|
-| `platform`        | **Yes**  | The platform name, should be "TedeeBridge"                                                  |
-| `apiKey`          | **Yes**  | The API key for your Tedee bridge                                                           |
-| `devices`         | No       | Array of your devices managed by the bridge                                                 |
-| `bridgeIp`        | No       | The IP address of your Tedee bridge                                                         |
-| `maximumApiRetry` | No       | The amount of attempts to call the Bridge API. Defaults to `3` attempts (incl. initial one) |
-| `timeout`         | No       | The timeout for the API calls in milliseconds. Defaults to `10000` ms                       |
-| `webhookPort`     | No       | The port on which the callback server should listen. Defaults to `3003`                     |
+| Parameter         | Required | Description                                                                                                                |
+|-------------------|----------|----------------------------------------------------------------------------------------------------------------------------|
+| `platform`        | **Yes**  | The platform name, should be "TedeeBridge"                                                                                 |
+| `name`            | **Yes**  | A unique name for this bridge instance. When running multiple Tedee bridges, this **must** differ between platform blocks. |
+| `apiKey`          | **Yes**  | The API key for your Tedee bridge                                                                                          |
+| `devices`         | No       | Array of your devices managed by the bridge                                                                                |
+| `bridgeIp`        | No       | The IP address of your Tedee bridge                                                                                        |
+| `maximumApiRetry` | No       | The amount of attempts to call the Bridge API. Defaults to `3` attempts (incl. initial one)                                |
+| `timeout`         | No       | The timeout for the API calls in milliseconds. Defaults to `10000` ms                                                      |
+| `webhookPort`     | No       | The port on which the callback server should listen. Defaults to `3003`                                                    |
+
+### Running Multiple Bridges
+
+To use this plugin with more than one Tedee bridge, add one platform block per bridge to your `config.json` and make sure each one has:
+
+* a unique `name`
+* a unique `webhookPort` (otherwise the second instance will fail with `EADDRINUSE`)
+* an explicit `bridgeIp` (auto-discovery may otherwise pick the same bridge for both instances)
+
+```json
+{
+  "platforms": [
+    {
+      "platform": "TedeeBridge",
+      "name": "Tedee Home",
+      "apiKey": "API-KEY-1",
+      "bridgeIp": "192.168.0.20",
+      "webhookPort": 3003
+    },
+    {
+      "platform": "TedeeBridge",
+      "name": "Tedee Office",
+      "apiKey": "API-KEY-2",
+      "bridgeIp": "192.168.0.21",
+      "webhookPort": 3004
+    }
+  ]
+}
+```
 
 ##### Device
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -3,10 +3,16 @@
   "pluginType": "platform",
   "headerDisplay": "Connect your Tedee smart locks with homebridge.",
   "footerDisplay": "The Tedee bridge is required for this plugin to work.",
-  "singular": true,
   "schema": {
     "type": "object",
     "properties": {
+      "name": {
+        "title": "Platform name",
+        "type": "string",
+        "required": true,
+        "default": "TedeeBridge",
+        "description": "A unique name for this bridge instance. Required when running more than one Tedee bridge — must differ between instances."
+      },
       "bridgeIp": {
         "title": "The local Bridge IP",
         "type": "string",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "url": "https://github.com/lpostiglione/homebridge-tedee-bridge/issues"
   },
   "engines": {
-    "node": "^18.17.0 || ^20.9.0",
-    "homebridge": "^1.6.0"
+    "node": "^18.20.4 || ^20.15.1 || ^22 || ^24",
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/src/clients/models/webhook-payload.ts
+++ b/src/clients/models/webhook-payload.ts
@@ -8,7 +8,20 @@ import {CommonDeviceEvent} from './common-device-event';
  * Represents the HTTP API model for a single lock.
  */
 export interface WebhookPayload {
-  event: 'backend-connection-changed' | 'device-connection-changed' | 'device-settings-changed' | 'lock-status-changed' | 'device-battery-level-changed' | 'device-battery-start-charging' | 'device-battery-stop-charging' | 'device-battery-fully-charged';
-  timestamp: string,
-  data: BackendConnectionChangedEvent | DeviceConnectionChangedEvent | DeviceBatteryLevelChangedEvent | LockStatusChangedEvent | CommonDeviceEvent;
+  event:
+    | 'backend-connection-changed'
+    | 'device-connection-changed'
+    | 'device-settings-changed'
+    | 'lock-status-changed'
+    | 'device-battery-level-changed'
+    | 'device-battery-start-charging'
+    | 'device-battery-stop-charging'
+    | 'device-battery-fully-charged';
+  timestamp: string;
+  data:
+    | BackendConnectionChangedEvent
+    | DeviceConnectionChangedEvent
+    | DeviceBatteryLevelChangedEvent
+    | LockStatusChangedEvent
+    | CommonDeviceEvent;
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -6,6 +6,9 @@ import {TedeeLocalApiClient} from './clients/tedee-local-api-client';
 import os from 'os';
 import {createServer, IncomingMessage, Server, ServerResponse} from 'http';
 import {WebhookPayload} from './clients/models/webhook-payload';
+import {DeviceBatteryLevelChangedEvent} from './clients/models/device-battery-level-changed-event';
+import {LockStatusChangedEvent} from './clients/models/lock-status-changed-event';
+import {CommonDeviceEvent} from './clients/models/common-device-event';
 import Evilscan from 'evilscan';
 import fs from 'fs';
 
@@ -28,7 +31,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
    * Contains the client that is used to communicate via HTTP API.
    */
   private _apiClient: TedeeLocalApiClient | null = null;
-  private _server: Server<typeof IncomingMessage, typeof ServerResponse> | undefined
+  private _server: Server<typeof IncomingMessage, typeof ServerResponse> | undefined;
   private callbackId: number | undefined;
 
   /**
@@ -73,9 +76,9 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
     this.api.on('didFinishLaunching', () => {
       this.discoverBridge()
         .then((addr) => {
-          this.connectBridge(addr)
+          this.connectBridge(addr);
           this.discoverDevices();
-        }, (e) => {
+        }, () => {
           this.log.warn('Failed to discover bridge!');
         });
     });
@@ -97,7 +100,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
   }
 
   discoverBridge(): Promise<string> {
-    this.log.info(`Discovering tedee bridge...`);
+    this.log.info('Discovering tedee bridge...');
     return new Promise((resolve, reject) => {
       if (this.config.bridgeIp) {
         // Proceed with the provided IP
@@ -133,8 +136,8 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
       };
 
       const scan = new Evilscan(options);
-      const results: { ip: string, reverse: string }[] = [];
-      scan.on('result', (data: { ip: string, reverse: string }) => {
+      const results: { ip: string; reverse: string }[] = [];
+      scan.on('result', (data: { ip: string; reverse: string }) => {
         this.log.debug(`Found device at ${data.ip} (${data.reverse})`);
         results.push({ip: data.ip, reverse: data.reverse});
       });
@@ -155,7 +158,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
             reject(new Error('No bridge found in the network'));
             return;
           }
-          const nextAddr = next.reverse && next.reverse != '' ? next.reverse : next.ip;
+          const nextAddr = next.reverse && next.reverse !== '' ? next.reverse : next.ip;
           this.checkForBridgeApi(nextAddr)
             .then(
               (addr) => resolve(addr),
@@ -163,7 +166,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
                 checkNext(results);
               },
             );
-        }
+        };
         checkNext(results);
       });
 
@@ -193,7 +196,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
           } else {
             reject(new Error('API Check Fail! Trying next IP if available...'));
           }
-        })
+        });
     });
   }
 
@@ -204,7 +207,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
 
     // Iterate through each network interface
     for (const iface of Object.values(interfaces)) {
-      // @ts-ignore
+      // @ts-expect-error iface is possibly undefined per Node typings
       for (const config of iface) {
         // Check if the address is IPv4 and not an internal (loopback) address
         if (config.family === 'IPv4' && !config.internal) {
@@ -256,14 +259,14 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
         this.log.debug(`Found ${locks.length} locks.`);
         this.log.debug(`Locks: ${JSON.stringify(locks)}`);
 
-        this.registerLocks(locks)
+        this.registerLocks(locks);
       })
       .catch(e => {
         this.log.error('Failed to get locks from the API');
         this.log.debug(JSON.stringify(e));
         return;
 
-      })
+      });
   }
 
   registerLocks(locks) {
@@ -273,7 +276,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
     const validUuids: string[] = [];
 
     for (const lock of locks) {
-      let deviceConfiguration = this.config.devices.find(l => l.name === lock.name);
+      let deviceConfiguration = this.config.devices?.find(l => l.name === lock.name);
       if (!deviceConfiguration) {
         deviceConfiguration = {
           name: lock.name,
@@ -283,7 +286,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
           disableUnlock: false,
           defaultLockName: lock.name,
           defaultLatchName: lock.name + ' Latch',
-        }
+        };
       }
 
       // generate a unique id for the accessory this should be generated from
@@ -357,11 +360,21 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
     }
 
     this.log.info(`Starting webhook server on port ${this.config.webhookPort}...`);
-    this._server = createServer((req, res) => this.handleWebhook(req, res))
-      .listen(this.config.webhookPort);
-    this.log.info(`Webhook server started successfully!`);
+    this._server = createServer((req, res) => this.handleWebhook(req, res));
+    this._server.on('error', (e: NodeJS.ErrnoException) => {
+      if (e.code === 'EADDRINUSE') {
+        this.log.error(
+          `Webhook port ${this.config.webhookPort} is already in use. ` +
+          'When running multiple TedeeBridge instances, set a different "webhookPort" for each.',
+        );
+      } else {
+        this.log.error(`Webhook server error: ${e.message}`);
+      }
+    });
+    this._server.listen(this.config.webhookPort);
+    this.log.info('Webhook server started successfully!');
 
-    this.log.info(`Registering webhook callback...`);
+    this.log.info('Registering webhook callback...');
     const webhookUrl = `http://${this.getHomebridgeIpAddress()}:${this.config.webhookPort}/`;
     this.log.debug(`Webhook URL: ${webhookUrl}`);
 
@@ -371,7 +384,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
       headers: [],
     }]).then(callback => {
       this.log.debug(`Callback response: ${JSON.stringify(callback)}`);
-      this.log.info(`Webhook callback registered successfully!`);
+      this.log.info('Webhook callback registered successfully!');
       this.log.debug(`Callback ID: ${callback[0]}`);
       this.callbackId = callback[0];
     }).catch(e => {
@@ -384,7 +397,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
   private getHomebridgeIpAddress() {
     const networkInterfaces = os.networkInterfaces();
     for (const name of Object.keys(networkInterfaces)) {
-      // @ts-ignore
+      // @ts-expect-error networkInterfaces[name] is possibly undefined per Node typings
       for (const net of networkInterfaces[name]) {
         // Skip over non-IPv4 and internal (i.e. 127.0.0.1) addresses
         if (net.family === 'IPv4' && !net.internal) {
@@ -402,15 +415,26 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
         return;
       }
       // Parse the current configuration
-      let config = JSON.parse(data);
+      const config = JSON.parse(data);
 
-      // Find the platform with "platform" key equals "TedeeBridge"
-      let targetPlatform = config.platforms.find(p => p.platform === PLATFORM_NAME);
+      // Find this platform's own config block. With multiple instances we must
+      // match on name as well, otherwise every instance would overwrite the
+      // bridgeIp of the first TedeeBridge entry.
+      const matching = config.platforms.filter(p => p.platform === PLATFORM_NAME);
+      let targetPlatform;
+      if (matching.length <= 1) {
+        targetPlatform = matching[0];
+      } else {
+        targetPlatform = matching.find(p => p.name === this.config.name);
+      }
       if (targetPlatform) {
         targetPlatform.bridgeIp = addr;
         this.log.debug('Updated config with new IP:', targetPlatform.bridgeIp);
       } else {
-        this.log.debug('No matching platform found.');
+        this.log.debug(
+          `No matching platform found for name "${this.config.name}". ` +
+          'Set a unique "name" on each TedeeBridge platform when running multiple instances.',
+        );
         return;
       }
 
@@ -433,12 +457,12 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
     }
 
     const payload: WebhookPayload = JSON.parse(body);
-    if (payload.event == 'backend-connection-changed' || payload.event == 'device-connection-changed') {
-      if (payload.event == 'backend-connection-changed') {
-        // @ts-ignore
+    if (payload.event === 'backend-connection-changed' || payload.event === 'device-connection-changed') {
+      if (payload.event === 'backend-connection-changed') {
+        // @ts-expect-error payload.data is a discriminated union; isConnected exists on this branch
         this.log.info('Webhook: Backend ' + (payload.data.isConnected ? 'connected' : 'disconnected'));
       } else {
-        // @ts-ignore
+        // @ts-expect-error payload.data is a discriminated union; deviceId/isConnected exist on this branch
         this.log.info('Webhook: Device with id ' + payload.data.deviceId + ' ' + (payload.data.isConnected ? 'connected' : 'disconnected'));
 
       }
@@ -447,7 +471,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    // @ts-ignore
+    // @ts-expect-error payload.data is narrowed by the runtime event check above
     const data: DeviceBatteryLevelChangedEvent | LockStatusChangedEvent | CommonDeviceEvent = payload.data;
 
     // Identify the lock that needs to be updated
@@ -475,13 +499,11 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
         break;
       case 'device-battery-level-changed':
         this.log.info('Webhook: Battery level changed for device with id ' + data.deviceId);
-        // @ts-ignore
-        lock.updateBattery(data.batteryLevel);
+        lock.updateBattery((data as DeviceBatteryLevelChangedEvent).batteryLevel);
         break;
       case 'lock-status-changed':
         this.log.info('Webhook: Lock status changed for device with id ' + data.deviceId);
-        // @ts-ignore
-        lock.updateState(data.state, data.jammed);
+        lock.updateState((data as LockStatusChangedEvent).state, (data as LockStatusChangedEvent).jammed);
         break;
       default:
         this.log.warn('Webhook: Unknown event type ' + payload.event);
@@ -496,7 +518,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
 
   shutdown() {
     if (this.callbackId) {
-      this.log.info(`Deleting webhook callback...`);
+      this.log.info('Deleting webhook callback...');
       this.apiClient.deleteCallback(this.callbackId)
         .then(() => {
           this.log.debug('Webhook callback deleted successfully!');
@@ -509,7 +531,7 @@ export class HomebridgeTedeePlatform implements DynamicPlatformPlugin {
 
     // Close the server
     if (this._server) {
-      this.log.info(`Shutting down webhook server...`);
+      this.log.info('Shutting down webhook server...');
       this.server.close((e) => {
         if (e) {
           this.log.error('Failed to shut down webhook server!');

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -37,17 +37,29 @@ export class LockAccessory {
     // set accessory information
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'tedee')
-      .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.device.type == 2 ? 'Lock PRO' : 'Lock GO')
+      .setCharacteristic(
+        this.platform.Characteristic.Model,
+        this.accessory.context.device.type === 2 ? 'Lock PRO' : 'Lock GO',
+      )
       .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.device.serialNumber)
       .setCharacteristic(this.platform.Characteristic.FirmwareRevision, this.accessory.context.device.version)
       .setCharacteristic(this.platform.Characteristic.HardwareRevision, this.accessory.context.device.deviceRevision.toString());
 
-    this.state.isJammed = this.accessory.context.device.jammed == 1 || this.accessory.context.device.state == 0 || this.accessory.context.device.state == 1;
-    this.state.state = this.accessory.context.device.state;
-    this.state.isOperating = !(this.state.state == 0 || this.state.state == 2 || this.state.state == 3 || this.state.state == 6 || this.state.state == 9);
+    const ctxDevice = this.accessory.context.device;
+    this.state.isJammed = ctxDevice.jammed === 1 || ctxDevice.state === 0 || ctxDevice.state === 1;
+    this.state.state = ctxDevice.state;
+    this.state.isOperating = !(
+      this.state.state === 0 ||
+      this.state.state === 2 ||
+      this.state.state === 3 ||
+      this.state.state === 6 ||
+      this.state.state === 9
+    );
 
     // get the LockMechanism service if it exists, otherwise create a new LockMechanism service
-    this.service = this.accessory.getService(this.platform.Service.LockMechanism) || this.accessory.addService(this.platform.Service.LockMechanism);
+    this.service =
+      this.accessory.getService(this.platform.Service.LockMechanism) ||
+      this.accessory.addService(this.platform.Service.LockMechanism);
 
     this.service.setCharacteristic(this.platform.Characteristic.Name, this.name);
 
@@ -59,7 +71,7 @@ export class LockAccessory {
       .onSet(this.handleLockTargetStateSet.bind(this));
 
     this.state.batteryLevel = this.accessory.context.device.batteryLevel;
-    this.state.isCharging = this.accessory.context.device.isCharging == 1;
+    this.state.isCharging = this.accessory.context.device.isCharging === 1;
 
     this.battery = this.accessory.getService(this.platform.Service.Battery) || this.accessory.addService(this.platform.Service.Battery);
     this.battery.getCharacteristic(this.platform.Characteristic.StatusLowBattery)
@@ -104,7 +116,7 @@ export class LockAccessory {
       }
     } else {
       this.platform.log.warn(`[${this.name}] Invalid Operation requested.`);
-      this.platform.log.debug(`[${this.name}] Invalid LockTargetState requested: ${newValue}.`)
+      this.platform.log.debug(`[${this.name}] Invalid LockTargetState requested: ${newValue}.`);
       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.INVALID_VALUE_IN_REQUEST);
     }
   }
@@ -228,19 +240,19 @@ export class LockAccessory {
   }
 
   public updateCharging(isCharging: 0 | 1) {
-    this.state.isCharging = isCharging == 1;
+    this.state.isCharging = isCharging === 1;
 
     this.battery.updateCharacteristic(this.platform.Characteristic.ChargingState, this.handleStatusChargingStateGet());
   }
 
   public updateState(state: LockState, jammed: 0 | 1) {
-    if (state == 0 || state == 2 || state == 3 || state == 6 || state == 9) {
+    if (state === 0 || state === 2 || state === 3 || state === 6 || state === 9) {
       this.state.isOperating = false;
     }
 
     this.state.state = state;
 
-    this.state.isJammed = jammed == 1 || state == 0 || state == 1;
+    this.state.isJammed = jammed === 1 || state === 0 || state === 1;
 
     this.service.updateCharacteristic(this.platform.Characteristic.LockCurrentState, this.handleLockCurrentStateGet());
     this.service.updateCharacteristic(this.platform.Characteristic.LockTargetState, this.handleLockTargetStateGet());


### PR DESCRIPTION
## Summary

Three independent improvements bundled together because they touch overlapping files:

1. **Run more than one Tedee bridge in the same Homebridge instance** — currently impossible.
2. **Homebridge v2 / Node 22+24 compatibility** — declare the wider engine range and adopt the v2 plugin contract.
3. **Lint clean-up** — clear all pre-existing eslint errors and warnings under the existing `--max-warnings=0` config.

Verified on Homebridge OS 1.11.4 with two physical Tedee bridges. `npm run lint` and `npm run build` both exit 0 on this branch.

## 1. Multi-bridge support

The plugin currently assumes a single bridge. Anyone with two Tedee bridges (e.g. home + office, or two separate networks) can't use this plugin for both — only the first config block ever takes effect, and various pieces of state quietly stomp on each other.

Three independent issues, each enough on its own to break a second instance:

- **`config.schema.json` had `\"singular\": true`** — the Homebridge Config UI refuses to add a second platform entry, even though Homebridge core supports multiple platform instances of the same plugin.
- **`saveAddr()` matched the config block on `platform === 'TedeeBridge'` only** — `find()` returns the first hit, so with two TedeeBridge entries both instances would write their (re-)discovered IP into the *first* block on every restart, clobbering each other.
- **Default `webhookPort: 3003` collides** — the second instance's `createServer().listen(3003)` would throw `EADDRINUSE` and the webhook server (and lock state updates) silently dies.

Changes:
- Drop `\"singular\": true\"` from `config.schema.json` so the Homebridge UI permits more than one TedeeBridge entry.
- Add a required `name` field to the schema. Used to disambiguate which platform block belongs to which instance.
- Rewrite `saveAddr()` to match the platform block by `platform === PLATFORM_NAME && name === this.config.name` when more than one TedeeBridge entry is present. Single-instance configs keep the original behaviour — no migration needed.
- Add an `error` listener on the webhook server so a port collision logs an actionable message (\"port X already in use; set a different webhookPort for each instance\") instead of crashing.

Bonus fix: `registerLocks()` called `this.config.devices.find(...)` unconditionally, but `devices` is marked optional in the schema. Anyone who omits the `devices` block hit a `Cannot read properties of undefined` on startup. Switched to optional chaining.

### How to use multiple bridges

Each platform block needs three things to be unique: `name`, `webhookPort`, and ideally an explicit `bridgeIp` (auto-discovery may otherwise pick the same bridge for both):

```json
{
  \"platforms\": [
    {
      \"platform\": \"TedeeBridge\",
      \"name\": \"Tedee Home\",
      \"apiKey\": \"API-KEY-1\",
      \"bridgeIp\": \"192.168.0.20\",
      \"webhookPort\": 3003
    },
    {
      \"platform\": \"TedeeBridge\",
      \"name\": \"Tedee Office\",
      \"apiKey\": \"API-KEY-2\",
      \"bridgeIp\": \"192.168.0.21\",
      \"webhookPort\": 3004
    }
  ]
}
```

## 2. Homebridge v2 / Node 22+24 compatibility

Widens engines to silence the engine warning seen on Homebridge OS's Node 24 builds and to declare Homebridge v2 compatibility:

```json
\"engines\": {
  \"node\":      \"^18.20.4 || ^20.15.1 || ^22 || ^24\",
  \"homebridge\": \"^1.6.0 || ^2.0.0-beta.0\"
}
```

The plugin already uses the v2-compatible `Service.Battery` API; none of the v2-removed APIs are referenced (`BatteryService`, `Characteristic.Units`/`Formats`/`Perms`, `getValue()`, `getServiceByUUIDAndSubType`, `updateReachability`, `setPrimaryService`, `cameraSource`, `storagePath`). No code changes were required for v2 — only the engines field.

## 3. Lint clean-up

`master` reports 10 errors and ~50 warnings under the project's existing `\"max-warnings\": 0` lint config; this PR brings it to zero of each:

- `@ts-ignore` → `@ts-expect-error` where suppression is still needed; in two webhook-handler cases TS can resolve the discriminated union directly with type assertions, so the directive was removed.
- `==` / `!=` → `===` / `!==` throughout. Operands are already same-typed in every case (no behaviour change).
- Wrap long log strings (`webhook port already in use…`, `no matching platform found for name…`, model setter, large discriminated-union types) to satisfy the 140-char `max-len` rule.
- Drop an unused `e` parameter in the `discoverBridge` rejection callback.

## Backwards compatibility

- **Single-bridge users**: zero change in behaviour. The `name` field defaults sensibly and `saveAddr()`'s single-instance path is unchanged.
- **No config migration required.** Adding a `name` to an existing platform block is enough; auto-fill via the Config UI handles it for fresh installs.
- **No version bump in this PR** — left for the maintainer to choose.

## Testing

- `npm run lint` exits 0 (was failing on `master`).
- `npm run build` (`tsc`) exits 0 with no errors or warnings.
- Confirmed on Homebridge OS 1.11.4 with two physical Tedee bridges:
  - Both platforms initialize, discover their bridge, and register their locks.
  - Both webhook servers come up on distinct ports without collision.
  - HomeKit shows locks from both bridges and lock-state webhooks route to the correct instance via `data.deviceId`.

## Files changed

- `config.schema.json` — drop `singular`, add `name`
- `src/platform.ts` — saveAddr rewrite, webhook error handler, devices optional-chain, lint fixes
- `src/platformAccessory.ts` — eqeqeq + max-len lint fixes
- `src/clients/models/webhook-payload.ts` — max-len lint fix on the discriminated-union types
- `package.json` — engines widened
- `README.md` — add `name` to the config example/table, add a \"Running Multiple Bridges\" section
- `CHANGELOG.md` — entry under Unreleased